### PR TITLE
Tokenised2 - Token Input 

### DIFF
--- a/include/BlockchainExplorerData.h
+++ b/include/BlockchainExplorerData.h
@@ -54,6 +54,7 @@ struct TransactionInputToKeyDetails {
   std::vector<uint32_t> outputIndexes;
   crypto::KeyImage keyImage;
   uint64_t mixin;
+  uint64_t token_tx_index;
   TransactionOutputReferenceDetails output;
 };
 

--- a/include/CryptoNote.h
+++ b/include/CryptoNote.h
@@ -40,9 +40,25 @@ struct MultisignatureOutput {
   uint32_t term;
 };
 
-typedef boost::variant<BaseInput, KeyInput, MultisignatureInput> TransactionInput;
+// token input & output
+struct TokenInput
+{
+  crypto::KeyImage keyImage;
+  uint64_t amount;
+  uint32_t token_tx_index;
+  uint32_t outputIndex;
+};
 
-typedef boost::variant<KeyOutput, MultisignatureOutput> TransactionOutputTarget;
+struct TokenOutput
+{
+  crypto::PublicKey key;
+  uint64_t token_id;
+};
+//
+
+typedef boost::variant<BaseInput, KeyInput, MultisignatureInput, TokenInput> TransactionInput;
+
+typedef boost::variant<KeyOutput, MultisignatureOutput, TokenOutput> TransactionOutputTarget;
 
 struct TransactionOutput {
   uint64_t amount;

--- a/include/ITokenised.h
+++ b/include/ITokenised.h
@@ -1,0 +1,57 @@
+
+#pragma once
+
+#include <boost/optional.hpp>
+
+#include "CryptoTypes.h"
+#include "CryptoNoteCore/CryptoNoteBasic.h"
+
+namespace cn
+{
+  typedef size_t TokenTxId;
+  const TokenTxId WALLET_LEGACY_INVALID_TOKEN_TX_ID = std::numeric_limits<TokenTxId>::max();
+
+  struct token_data
+  {
+    uint64_t token_id;
+    uint64_t circulation;
+    uint64_t token_txs;
+  };
+
+  struct token_send
+  {
+    uint64_t amount;
+    std::string address;
+    uint64_t token_id;
+  };
+
+  enum class token_state : uint8_t
+  {
+    Active,    // --> {Deleted}
+    Deleted,   // --> {Active}
+
+    Sending,   // --> {Active, Cancelled, Failed}
+    Cancelled, // --> {}
+    Failed     // --> {}
+  };
+
+  struct token_transaction_data
+  {
+    TokenTxId       firstTransferId;
+    size_t          transferCount;
+
+    uint64_t        totalAmount;
+    uint64_t        fee;
+
+    uint64_t        sentTime;
+    uint64_t        unlockTime;
+    uint32_t        blockHeight;
+    uint64_t        timestamp;
+
+    crypto::Hash    hash;
+    boost::optional<crypto::SecretKey> secretKey = cn::NULL_SECRET_KEY;
+
+    token_state state;
+  };
+  
+}

--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -18,8 +18,8 @@ namespace cn {
 
 namespace transaction_types {
   
-  enum class InputType : uint8_t { Invalid, Key, Multisignature, Generating };
-  enum class OutputType : uint8_t { Invalid, Key, Multisignature };
+  enum class InputType : uint8_t { Invalid, Key, Multisignature, Token, Generating };
+  enum class OutputType : uint8_t { Invalid, Key, Multisignature, Token };
 
   struct GlobalOutput {
     crypto::PublicKey targetKey;
@@ -66,6 +66,7 @@ public:
   virtual transaction_types::InputType getInputType(size_t index) const = 0;
   virtual void getInput(size_t index, KeyInput& input) const = 0;
   virtual void getInput(size_t index, MultisignatureInput& input) const = 0;
+  virtual void getInput(size_t index, TokenInput& input) const = 0;
   virtual std::vector<TransactionInput> getInputs() const = 0;
   // outputs
   virtual size_t getOutputCount() const = 0;
@@ -107,6 +108,7 @@ public:
   // Inputs/Outputs 
   virtual size_t addInput(const KeyInput& input) = 0;
   virtual size_t addInput(const MultisignatureInput& input) = 0;
+  virtual size_t addInput(const TokenInput& input) = 0;
   virtual size_t addInput(const AccountKeys& senderKeys, const transaction_types::InputKeyInfo& info, KeyPair& ephKeys) = 0;
 
   virtual size_t addOutput(uint64_t amount, const AccountPublicAddress& to) = 0;

--- a/include/ITransfersContainer.h
+++ b/include/ITransfersContainer.h
@@ -35,6 +35,7 @@ namespace cn
     std::vector<uint8_t> extra;
     crypto::Hash paymentId;
     std::vector<std::string> messages;
+    uint64_t token_id;
   };
 
   struct TransactionOutputInformation
@@ -44,6 +45,7 @@ namespace cn
     uint64_t amount;
     uint32_t globalOutputIndex;
     uint32_t outputInTransaction;
+    uint64_t global_token_output_index;
 
     // transaction info
     crypto::Hash transactionHash;
@@ -106,8 +108,10 @@ namespace cn
     };
 
     virtual size_t transfersCount() const = 0;
+    virtual size_t transfersTokenCount() const = 0;
     virtual size_t transactionsCount() const = 0;
     virtual uint64_t balance(uint32_t flags = IncludeDefault) const = 0;
+    virtual uint64_t token_balance(uint32_t flags = IncludeDefault) const = 0;
     virtual void getOutputs(std::vector<TransactionOutputInformation> &transfers, uint32_t flags = IncludeDefault) const = 0;
     virtual bool getTransactionInformation(const crypto::Hash &transactionHash, TransactionInformation &info,
                                            uint64_t *amountIn = nullptr, uint64_t *amountOut = nullptr) const = 0;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -152,7 +152,8 @@ namespace cn
 	const uint64_t GENESIS_TIMESTAMP = 1527078920;
 
 	const uint8_t TRANSACTION_VERSION_1 = 1;
-	const uint8_t TRANSACTION_VERSION_2 = 2;
+	const uint8_t TRANSACTION_VERSION_2 = 2; // multisig deposits
+	const uint8_t TRANSACTION_VERSION_3 = 3; // tokens
 	const uint8_t BLOCK_MAJOR_VERSION_1 = 1; // (Consensus I)
 	const uint8_t BLOCK_MAJOR_VERSION_2 = 2; // (Consensus II)
 	const uint8_t BLOCK_MAJOR_VERSION_3 = 3; // (Consensus III)

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -958,6 +958,11 @@ bool core::getBlockContainingTx(const crypto::Hash& txId, crypto::Hash& blockId,
   return m_blockchain.getBlockContainingTransaction(txId, blockId, blockHeight);
 }
 
+bool core::get_token_output_ref(const TokenInput& txInToken, std::pair<crypto::Hash, size_t>& outputReference)
+{
+  return m_blockchain.get_token_output_ref(txInToken, outputReference);
+}
+
 bool core::getMultisigOutputReference(const MultisignatureInput& txInMultisig, std::pair<crypto::Hash, size_t>& outputReference) {
   return m_blockchain.getMultisigOutputReference(txInMultisig, outputReference);
 }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -70,6 +70,7 @@ namespace cn {
      virtual bool getBlockDifficulty(uint32_t height, difficulty_type& difficulty) override;
      virtual bool getBlockTimestamp(uint32_t height, uint64_t &timestamp) override;
      virtual bool getBlockContainingTx(const crypto::Hash& txId, crypto::Hash& blockId, uint32_t& blockHeight) override;
+     virtual bool get_token_output_ref(const TokenInput& txInToken, std::pair<crypto::Hash, size_t>& output_reference) override;
      virtual bool getMultisigOutputReference(const MultisignatureInput& txInMultisig, std::pair<crypto::Hash, size_t>& output_reference) override;
      virtual bool getGeneratedTransactionsNumber(uint32_t height, uint64_t& generatedTransactions) override;
      virtual bool getOrphanBlocksByHeight(uint32_t height, std::vector<Block>& blocks) override;

--- a/src/CryptoNoteCore/CryptoNoteSerialization.h
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.h
@@ -38,11 +38,13 @@ void serialize(TransactionOutput& in, ISerializer& serializer);
 void serialize(BaseInput& gen, ISerializer& serializer);
 void serialize(KeyInput& key, ISerializer& serializer);
 void serialize(MultisignatureInput& multisignature, ISerializer& serializer);
+void serialize(TokenInput& token, ISerializer& serializer);
 
 void serialize(TransactionOutput& output, ISerializer& serializer);
 void serialize(TransactionOutputTarget& output, ISerializer& serializer);
 void serialize(KeyOutput& key, ISerializer& serializer);
 void serialize(MultisignatureOutput& multisignature, ISerializer& serializer);
+void serialize(TokenOutput& token, ISerializer& serializer);
 
 void serialize(BlockHeader& header, ISerializer& serializer);
 void serialize(Block& block, ISerializer& serializer);

--- a/src/CryptoNoteCore/CryptoNoteTools.cpp
+++ b/src/CryptoNoteCore/CryptoNoteTools.cpp
@@ -41,6 +41,9 @@ uint64_t getInputAmount(const Transaction& transaction) {
     } else if (input.type() == typeid(MultisignatureInput)) {
       amount += boost::get<MultisignatureInput>(input).amount;
     }
+    else if (input.type() == typeid(TokenInput)) {
+      amount += boost::get<TokenInput>(input).amount;
+    }
   }
 
   return amount;
@@ -55,6 +58,8 @@ std::vector<uint64_t> getInputsAmounts(const Transaction& transaction) {
       inputsAmounts.push_back(boost::get<KeyInput>(input).amount);
     } else if (input.type() == typeid(MultisignatureInput)) {
       inputsAmounts.push_back(boost::get<MultisignatureInput>(input).amount);
+    } else if (input.type() == typeid(TokenInput)) {
+      inputsAmounts.push_back(boost::get<TokenInput>(input).amount);
     }
   }
 

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -460,6 +460,10 @@ namespace cn
         return multisignatureInput.amount + calculateInterest(multisignatureInput.amount, multisignatureInput.term, height);
       }
     }
+    else if (in.type() == typeid(TokenInput))
+    {
+      return boost::get<TokenInput>(in).amount;
+    }
     else if (in.type() == typeid(BaseInput))
     {
       return 0;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -38,6 +38,7 @@ struct core_stat_info;
 struct i_cryptonote_protocol;
 struct Transaction;
 struct MultisignatureInput;
+struct TokenInput;
 struct KeyInput;
 struct TransactionPrefixInfo;
 struct tx_verification_context;
@@ -100,6 +101,7 @@ public:
   virtual bool getBlockDifficulty(uint32_t height, difficulty_type& difficulty) = 0;
   virtual bool getBlockTimestamp(uint32_t height, uint64_t &timestamp) = 0;
   virtual bool getBlockContainingTx(const crypto::Hash& txId, crypto::Hash& blockId, uint32_t& blockHeight) = 0;
+  virtual bool get_token_output_ref(const TokenInput& txInToken, std::pair<crypto::Hash, size_t>& output_reference) = 0;
   virtual bool getMultisigOutputReference(const MultisignatureInput& txInMultisig, std::pair<crypto::Hash, size_t>& outputReference) = 0;
   virtual bool getTransaction(const crypto::Hash &id, Transaction &tx, bool checkTxPool = false) = 0;
   virtual bool getGeneratedTransactionsNumber(uint32_t height, uint64_t& generatedTransactions) = 0;

--- a/src/CryptoNoteCore/Transaction.cpp
+++ b/src/CryptoNoteCore/Transaction.cpp
@@ -61,6 +61,7 @@ namespace cn {
     virtual transaction_types::InputType getInputType(size_t index) const override;
     virtual void getInput(size_t index, KeyInput& input) const override;
     virtual void getInput(size_t index, MultisignatureInput& input) const override;
+    virtual void getInput(size_t index, TokenInput& input) const override;
     virtual std::vector<TransactionInput> getInputs() const override;
 
     // outputs
@@ -91,6 +92,7 @@ namespace cn {
     // Inputs/Outputs 
     virtual size_t addInput(const KeyInput& input) override;
     virtual size_t addInput(const MultisignatureInput& input) override;
+    virtual size_t addInput(const TokenInput& input) override;
     virtual size_t addInput(const AccountKeys& senderKeys, const transaction_types::InputKeyInfo& info, KeyPair& ephKeys) override;
 
     virtual size_t addOutput(uint64_t amount, const AccountPublicAddress& to) override;
@@ -269,6 +271,14 @@ namespace cn {
     checkIfSigning();
     transaction.inputs.push_back(input);
     transaction.version = TRANSACTION_VERSION_2;
+    invalidateHash();
+    return transaction.inputs.size() - 1;
+  }
+
+  size_t TransactionImpl::addInput(const TokenInput& input) {
+    checkIfSigning();
+    transaction.inputs.push_back(input);
+    transaction.version = TRANSACTION_VERSION_3;
     invalidateHash();
     return transaction.inputs.size() - 1;
   }
@@ -472,6 +482,10 @@ namespace cn {
 
   void TransactionImpl::getInput(size_t index, MultisignatureInput& input) const {
     input = boost::get<MultisignatureInput>(getInputChecked(transaction, index, transaction_types::InputType::Multisignature));
+  }
+
+  void TransactionImpl::getInput(size_t index, TokenInput& input) const {
+    input = boost::get<TokenInput>(getInputChecked(transaction, index, transaction_types::InputType::Multisignature));
   }
 
   size_t TransactionImpl::getOutputCount() const {

--- a/src/CryptoNoteCore/TransactionPool.cpp
+++ b/src/CryptoNoteCore/TransactionPool.cpp
@@ -64,6 +64,12 @@ namespace cn
           (void)r; //just to make compiler to shut up
           assert(r.second);
         }
+        else if (in.type() == typeid(TokenInput))
+        {
+          auto r = m_keyImages.insert(boost::get<TokenInput>(in).keyImage);
+          (void)r; //just to make compiler to shut up
+          assert(r.second);
+        }
       }
 
       m_txHashes.push_back(txid);
@@ -91,6 +97,13 @@ namespace cn
         {
           const auto &msig = boost::get<MultisignatureInput>(in);
           if (m_usedOutputs.count(std::make_pair(msig.amount, msig.outputIndex)))
+          {
+            return false;
+          }
+        }
+        else if (in.type() == typeid(TokenInput))
+        {
+          if (m_keyImages.count(boost::get<TokenInput>(in).keyImage))
           {
             return false;
           }
@@ -776,6 +789,16 @@ namespace cn
           m_spentOutputs.erase(output);
         }
       }
+      else if (in.type() == typeid(TokenInput))
+      {
+        if (!keptByBlock)
+        {
+          const auto &tk = boost::get<TokenInput>(in);
+          auto output = GlobalOutput(tk.amount, tk.outputIndex);
+          assert(m_spentOutputs.count(output));
+          m_spentOutputs.erase(output);
+        }
+      }
     }
 
     return true;
@@ -816,6 +839,16 @@ namespace cn
           assert(r.second);
         }
       }
+      else if (in.type() == typeid(TokenInput))
+      {
+        if (!keptByBlock)
+        {
+          const auto &tk = boost::get<TokenInput>(in);
+          auto r = m_spentOutputs.insert(GlobalOutput(tk.amount, tk.outputIndex));
+          (void)r;
+          assert(r.second);
+        }
+      }
     }
 
     return true;
@@ -838,6 +871,14 @@ namespace cn
       {
         const auto &msig = boost::get<MultisignatureInput>(in);
         if (m_spentOutputs.count(GlobalOutput(msig.amount, msig.outputIndex)))
+        {
+          return true;
+        }
+      }
+      else if (in.type() == typeid(TokenInput))
+      {
+        const auto &tk = boost::get<TokenInput>(in);
+        if (m_spentOutputs.count(GlobalOutput(tk.amount, tk.outputIndex)))
         {
           return true;
         }

--- a/src/CryptoNoteCore/TransactionPrefixImpl.cpp
+++ b/src/CryptoNoteCore/TransactionPrefixImpl.cpp
@@ -43,6 +43,7 @@ public:
   virtual transaction_types::InputType getInputType(size_t index) const override;
   virtual void getInput(size_t index, KeyInput& input) const override;
   virtual void getInput(size_t index, MultisignatureInput& input) const override;
+  virtual void getInput(size_t index, TokenInput& input) const override;
   virtual std::vector<TransactionInput> getInputs() const override;
 
   // outputs
@@ -153,6 +154,10 @@ void TransactionPrefixImpl::getInput(size_t index, KeyInput& input) const {
 
 void TransactionPrefixImpl::getInput(size_t index, MultisignatureInput& input) const {
   input = boost::get<MultisignatureInput>(getInputChecked(m_txPrefix, index, transaction_types::InputType::Multisignature));
+}
+
+void TransactionPrefixImpl::getInput(size_t index, TokenInput& input) const {
+  input = boost::get<TokenInput>(getInputChecked(m_txPrefix, index, transaction_types::InputType::Multisignature));
 }
 
 size_t TransactionPrefixImpl::getOutputCount() const {

--- a/src/CryptoNoteCore/TransactionUtils.cpp
+++ b/src/CryptoNoteCore/TransactionUtils.cpp
@@ -38,6 +38,9 @@ size_t getRequiredSignaturesCount(const TransactionInput& in) {
   if (in.type() == typeid(MultisignatureInput)) {
     return boost::get<MultisignatureInput>(in).signatureCount;
   }
+  if (in.type() == typeid(TokenInput)) {
+    return boost::get<TokenInput>(in).outputIndex;
+  }
   return 0;
 }
 
@@ -49,6 +52,9 @@ uint64_t getTransactionInputAmount(const TransactionInput& in) {
     // TODO calculate interest
     return boost::get<MultisignatureInput>(in).amount;
   }
+  if (in.type() == typeid(TokenInput)) {
+    return boost::get<TokenInput>(in).amount;
+  }
   return 0;
 }
 
@@ -58,6 +64,9 @@ transaction_types::InputType getTransactionInputType(const TransactionInput& in)
   }
   if (in.type() == typeid(MultisignatureInput)) {
     return transaction_types::InputType::Multisignature;
+  }
+  if (in.type() == typeid(TokenInput)) {
+    return transaction_types::InputType::Token;
   }
   if (in.type() == typeid(BaseInput)) {
     return transaction_types::InputType::Generating;

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -330,7 +330,6 @@ int main(int argc, char* argv[])
     }
  
     rpcServer.start(rpcConfig.bindIp, rpcConfig.bindPort);
-    rpcServer.enableCors(rpcConfig.enableCors);
     logger(INFO) << "Core rpc server started ok";
 
     tools::SignalHandler::install([&dch, &p2psrv]

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -461,7 +461,7 @@ void NodeRpcProxy::isSynchronized(bool& syncStatus, const Callback& callback) {
     return;
   }
 
-  syncStatus = getPeerCount() > 0 && getLastLocalBlockHeight() >= getLastKnownBlockHeight();
+  // TODO NOT IMPLEMENTED
   callback(std::error_code());
 }
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -71,12 +71,9 @@ RpcServer::HandlerFunction jsonMethod(bool (RpcServer::*handler)(typename Comman
 
     bool result = (obj->*handler)(req, res);
 
-    std::string cors_domain = obj->getCorsDomain();
-    if (!cors_domain.empty()) {
-      response.addHeader("Access-Control-Allow-Origin", cors_domain);
-      response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-      response.addHeader("Access-Control-Allow-Methods", "POST, GET");
-    }
+    response.addHeader("Access-Control-Allow-Origin", "*");
+    response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    response.addHeader("Access-Control-Allow-Methods", "POST, GET");
     response.addHeader("Content-Type", "application/json");
 
     response.setBody(storeToJson(res.data()));
@@ -140,11 +137,9 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
   using namespace JsonRpc;
 
   response.addHeader("Content-Type", "application/json");
-  if (!m_cors_domain.empty()) {
-    response.addHeader("Access-Control-Allow-Origin", m_cors_domain);
-    response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-    response.addHeader("Access-Control-Allow-Methods", "POST, GET");
-  }  
+  response.addHeader("Access-Control-Allow-Origin", "*");
+  response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  response.addHeader("Access-Control-Allow-Methods", "POST, GET");
 
   JsonRpcRequest jsonRequest;
   JsonRpcResponse jsonResponse;
@@ -201,15 +196,6 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
 
 bool RpcServer::isCoreReady() {
   return m_core.currency().isTestnet() || m_p2p.get_payload_object().isSynchronized();
-}
-
-bool RpcServer::enableCors(const std::string domain) {
-  m_cors_domain = domain;
-  return true;
-}
-
-std::string RpcServer::getCorsDomain() {
-  return m_cors_domain;
 }
 
 //

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -28,10 +28,9 @@ public:
   bool setViewKey(const std::string& view_key);
   bool restrictRPC(const bool is_resctricted);
   bool k_on_check_tx_proof(const K_COMMAND_RPC_CHECK_TX_PROOF::request& req, K_COMMAND_RPC_CHECK_TX_PROOF::response& res);
-  bool k_on_check_reserve_proof(const K_COMMAND_RPC_CHECK_RESERVE_PROOF::request& req, K_COMMAND_RPC_CHECK_RESERVE_PROOF::response& res);
+  bool k_on_check_reserve_proof(const K_COMMAND_RPC_CHECK_RESERVE_PROOF::request& req, K_COMMAND_RPC_CHECK_RESERVE_PROOF::response& res);  
+  bool enableCors(const std::string domain);  
   bool remotenode_check_incoming_tx(const BinaryArray& tx_blob);
-  bool enableCors(const std::string domain);
-  std::string getCorsDomain();
 
 private:
 

--- a/src/Rpc/RpcServerConfig.cpp
+++ b/src/Rpc/RpcServerConfig.cpp
@@ -18,11 +18,10 @@ namespace cn {
 
     const command_line::arg_descriptor<std::string> arg_rpc_bind_ip = { "rpc-bind-ip", "", DEFAULT_RPC_IP };
     const command_line::arg_descriptor<uint16_t> arg_rpc_bind_port = { "rpc-bind-port", "", DEFAULT_RPC_PORT };
-    const command_line::arg_descriptor<std::string> arg_enable_cors = { "enable-cors", "Adds header 'Access-Control-Allow-Origin' to the daemon's RPC responses. Uses the value as domain. Use * for all", "" };
   }
 
 
-  RpcServerConfig::RpcServerConfig() : bindIp(DEFAULT_RPC_IP), bindPort(DEFAULT_RPC_PORT), enableCors("") {
+  RpcServerConfig::RpcServerConfig() : bindIp(DEFAULT_RPC_IP), bindPort(DEFAULT_RPC_PORT) {
   }
 
   std::string RpcServerConfig::getBindAddress() const {
@@ -32,7 +31,6 @@ namespace cn {
   void RpcServerConfig::initOptions(boost::program_options::options_description& desc) {
     command_line::add_arg(desc, arg_rpc_bind_ip);
     command_line::add_arg(desc, arg_rpc_bind_port);
-    command_line::add_arg(desc, arg_enable_cors);
   }
 
   void RpcServerConfig::init(const boost::program_options::variables_map &vm)
@@ -50,6 +48,5 @@ namespace cn {
         bindPort = argPort;
       }
     }
-    enableCors = command_line::get_arg(vm, arg_enable_cors);
   }
 }

--- a/src/Rpc/RpcServerConfig.h
+++ b/src/Rpc/RpcServerConfig.h
@@ -23,7 +23,6 @@ public:
 
   std::string bindIp;
   uint16_t bindPort;
-  std::string enableCors;
 };
 
 }

--- a/src/Transfers/TransfersContainer.h
+++ b/src/Transfers/TransfersContainer.h
@@ -134,11 +134,13 @@ struct TransactionBlockInfo {
   uint32_t height;
   uint64_t timestamp;
   uint32_t transactionIndex;
+  uint64_t token_index;
 
   void serialize(ISerializer& s) {
     serializeBlockHeight(s, height, "height");
     s(timestamp, "timestamp");
     s(transactionIndex, "transactionIndex");
+    s(token_index, "token_index");
   }
 };
 
@@ -201,7 +203,11 @@ public:
   // ITransfersContainer
   virtual size_t transfersCount() const override;
   virtual size_t transactionsCount() const override;
+  virtual size_t transfersTokenCount() const override;
+
   virtual uint64_t balance(uint32_t flags) const override;
+  virtual uint64_t token_balance(uint32_t flags) const override;
+
   virtual void getOutputs(std::vector<TransactionOutputInformation>& transfers, uint32_t flags) const override;
   virtual bool getTransactionInformation(const crypto::Hash& transactionHash, TransactionInformation& info,
     uint64_t* amountIn = nullptr, uint64_t* amountOut = nullptr) const override;
@@ -365,10 +371,17 @@ private:
 
 private:
   TransactionMultiIndex m_transactions;
+
   UnconfirmedTransfersMultiIndex m_unconfirmedTransfers;
   AvailableTransfersMultiIndex m_availableTransfers;
   SpentTransfersMultiIndex m_spentTransfers;
   TransfersUnlockMultiIndex m_transfersUnlockJobs;
+
+  UnconfirmedTransfersMultiIndex m_unconfirmedTokenTransfers;
+  AvailableTransfersMultiIndex m_availableTokenTransfers;
+  SpentTransfersMultiIndex m_spentTokenTransfers;
+  TransfersUnlockMultiIndex m_transfersTokenUnlockJobs;
+
   //std::unordered_map<KeyImage, KeyOutputInfo, boost::hash<KeyImage>> m_keyImages;
 
   uint32_t m_currentHeight; // current height is needed to check if a transfer is unlocked

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1099,7 +1099,9 @@ namespace cn
         m_transactions,
         m_transfers,
         m_transactionSoftLockTime,
-        m_uncommitedTransactions);
+        m_uncommitedTransactions,
+        m_token_transactions,
+        m_token_transfers);
 
     StdInputStream stream(walletFileStream);
     s.load(m_key, stream);

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -386,6 +386,9 @@ protected:
   mutable std::unordered_map<size_t, bool> m_fusionTxsCache; // txIndex -> isFusion
   UncommitedTransactions m_uncommitedTransactions;
 
+  WalletTokenTransactions m_token_transactions;
+  WalletTokenTransfers m_token_transfers;
+
   bool m_blockchainSynchronizerStarted;
   BlockchainSynchronizer m_blockchainSynchronizer;
   TransfersSyncronizer m_synchronizer;

--- a/src/Wallet/WalletIndices.h
+++ b/src/Wallet/WalletIndices.h
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 #include "ITransfersContainer.h"
+#include "ITokenised.h"
 #include "IWallet.h"
 #include "IWalletLegacy.h" //TODO: make common types for all of our APIs (such as PublicKey, KeyPair, etc)
 
@@ -124,7 +125,21 @@ struct EncryptedWalletRecord {
             boost::multi_index::ordered_non_unique<boost::multi_index::tag<BlockHeightIndex>,
                                                    boost::multi_index::member<cn::WalletTransaction, uint32_t, &cn::WalletTransaction::blockHeight>>>>
         WalletTransactions;
-        
+
+
+    typedef boost::multi_index_container<
+        cn::token_transaction_data,
+        boost::multi_index::indexed_by<
+            boost::multi_index::random_access<boost::multi_index::tag<RandomAccessIndex>>,
+            boost::multi_index::hashed_unique<boost::multi_index::tag<TransactionIndex>,
+                                              boost::multi_index::member<cn::token_transaction_data, crypto::Hash, &cn::token_transaction_data::hash>>,
+            boost::multi_index::ordered_non_unique<boost::multi_index::tag<BlockHeightIndex>,
+                                                   boost::multi_index::member<cn::token_transaction_data, uint32_t, &cn::token_transaction_data::blockHeight>>>>
+        WalletTokenTransactions;
+    typedef std::pair<size_t, cn::token_send> TokenTransactionTransferPair;
+    typedef std::vector<TokenTransactionTransferPair> WalletTokenTransfers;
+
+
     typedef common::FileMappedVector<EncryptedWalletRecord> ContainerStorage;
     typedef std::pair<size_t, cn::WalletTransfer> TransactionTransferPair;
     typedef std::vector<TransactionTransferPair> WalletTransfers;

--- a/src/Wallet/WalletSerializationV1.h
+++ b/src/Wallet/WalletSerializationV1.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "IWallet.h"
+#include "ITokenised.h"
 #include "WalletIndices.h"
 #include "Common/IInputStream.h"
 #include "Common/IOutputStream.h"
@@ -42,7 +43,9 @@ public:
       WalletTransactions &transactions,
       WalletTransfers &transfers,
       uint32_t transactionSoftLockTime,
-      UncommitedTransactions &uncommitedTransactions);
+      UncommitedTransactions &uncommitedTransactions,
+      WalletTokenTransactions &token_transactions,
+      WalletTokenTransfers &token_transfers);
 
   void save(const std::string &password, common::IOutputStream &destination, bool saveDetails, bool saveCache);
   void load(const crypto::chacha8_key &key, common::IInputStream &source);
@@ -91,6 +94,7 @@ private:
   void loadWalletV1Keys(cn::BinaryInputStreamSerializer &serializer);
   void loadWalletV1Details(cn::BinaryInputStreamSerializer &serializer);
   void addWalletV1Details(const std::vector<WalletLegacyTransaction> &txs, const std::vector<WalletLegacyTransfer> &trs);
+  void addWalletTokenV1Details(const std::vector<token_transaction_data> &txs, const std::vector<token_send> &trs);
   void initTransactionPool();
   void resetCachedBalance();
   void updateTransactionsBaseStatus();
@@ -108,6 +112,9 @@ private:
   WalletTransfers &m_transfers;
   uint32_t m_transactionSoftLockTime;
   UncommitedTransactions &uncommitedTransactions;
+
+  WalletTokenTransactions &m_token_transactions;
+  WalletTokenTransfers &m_token_transfers;
 };
 
 } //namespace cn

--- a/src/WalletLegacy/WalletLegacySerialization.cpp
+++ b/src/WalletLegacy/WalletLegacySerialization.cpp
@@ -79,9 +79,44 @@ void serialize(WalletLegacyTransaction& txi, cn::ISerializer& serializer) {
   txi.sentTime = 0;
 }
 
+void serialize(token_transaction_data& txi, cn::ISerializer& serializer) {
+  uint64_t trId = static_cast<uint64_t>(txi.firstTransferId);
+  serializer(trId, "first_transfer_id");
+  txi.firstTransferId = static_cast<size_t>(trId);
+
+  uint64_t trCount = static_cast<uint64_t>(txi.transferCount);
+  serializer(trCount, "transfer_count");
+  txi.transferCount = static_cast<size_t>(trCount);
+
+  serializer(txi.totalAmount, "total_amount");
+  serializer(txi.fee, "fee");
+
+  serializer(txi.hash, "hash");
+
+  cn::serializeBlockHeight(serializer, txi.blockHeight, "block_height");
+
+  serializer(txi.timestamp, "timestamp");
+  serializer(txi.unlockTime, "unlock_time");
+
+  uint8_t state = static_cast<uint8_t>(txi.state);
+  serializer(state, "state");
+  txi.state = static_cast<token_state>(state);
+
+  //this field has been added later in the structure.
+  //in order to not break backward binary compatibility
+  // we just set it to zero
+  txi.sentTime = 0;
+}
+
 void serialize(WalletLegacyTransfer& tr, cn::ISerializer& serializer) {
   serializer(tr.address, "address");
   serializer(tr.amount, "amount");
+}
+
+void serialize(token_send& tr, cn::ISerializer& serializer) {
+  serializer(tr.address, "address");
+  serializer(tr.amount, "amount");
+  serializer(tr.token_id, "token_id");
 }
 
 void serialize(Deposit& deposit, cn::ISerializer& serializer) {

--- a/src/WalletLegacy/WalletLegacySerialization.h
+++ b/src/WalletLegacy/WalletLegacySerialization.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "IWalletLegacy.h"
+#include "ITokenised.h"
 
 namespace cn {
 class ISerializer;
@@ -19,6 +20,10 @@ class ISerializer;
 struct UnconfirmedTransferDetails;
 struct WalletLegacyTransaction;
 struct WalletLegacyTransfer;
+
+struct token_send;
+struct token_transaction_data;
+
 struct DepositInfo;
 struct Deposit;
 struct UnconfirmedSpentDepositDetails;
@@ -27,6 +32,8 @@ void serialize(UnconfirmedTransferDetails& utd, ISerializer& serializer);
 void serialize(UnconfirmedSpentDepositDetails& details, ISerializer& serializer);
 void serialize(WalletLegacyTransaction& txi, ISerializer& serializer);
 void serialize(WalletLegacyTransfer& tr, ISerializer& serializer);
+void serialize(token_send& tr, ISerializer& serializer);
+void serialize(token_transaction_data& txi, ISerializer& serializer);
 void serialize(DepositInfo& depositInfo, ISerializer& serializer);
 void serialize(Deposit& deposit, ISerializer& serializer);
 

--- a/src/WalletLegacy/WalletSendTransactionContext.h
+++ b/src/WalletLegacy/WalletSendTransactionContext.h
@@ -37,6 +37,7 @@ struct SendTransactionContext
   std::vector<tx_message_entry> messages;
   uint64_t ttl;
   uint32_t depositTerm;
+  uint64_t token_id;
 };
 
 } //namespace cn

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -841,6 +841,26 @@ namespace cn
     return convertSources(std::move(sources));
   }
 
+  std::vector<TokenInput> WalletTransactionSender::prep_token_inputs(const std::vector<TransactionOutputInformation> &selectedTransfers)
+  {
+    std::vector<TokenInput> inputs;
+    inputs.reserve(selectedTransfers.size());
+
+    for (const auto &output : selectedTransfers)
+    {
+      assert(output.type == transaction_types::OutputType::Token);
+
+      TokenInput input;
+      input.amount = output.amount;
+      input.outputIndex = output.globalOutputIndex;
+      input.token_tx_index = output.global_token_output_index + 1;
+
+      inputs.emplace_back(std::move(input));
+    }
+
+    return inputs;
+  }
+
   std::vector<MultisignatureInput> WalletTransactionSender::prepareMultisignatureInputs(const std::vector<TransactionOutputInformation> &selectedTransfers)
   {
     std::vector<MultisignatureInput> inputs;

--- a/src/WalletLegacy/WalletTransactionSender.h
+++ b/src/WalletLegacy/WalletTransactionSender.h
@@ -87,6 +87,7 @@ private:
   std::vector<transaction_types::InputKeyInfo> prepareKeyInputs(const std::vector<TransactionOutputInformation>& selectedTransfers,
                                                                std::vector<COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS::outs_for_amount>& outs,
                                                                uint64_t mixIn);
+  std::vector<TokenInput> prep_token_inputs(const std::vector<TransactionOutputInformation>& selectedTransfers);
   std::vector<MultisignatureInput> prepareMultisignatureInputs(const std::vector<TransactionOutputInformation>& selectedTransfers);
   void splitDestinations(TransferId firstTransferId, size_t transfersCount, const TransactionDestinationEntry& changeDts,
     const TxDustPolicy& dustPolicy, std::vector<TransactionDestinationEntry>& splittedDests);


### PR DESCRIPTION
* different way of implementation
* created new KeyInput like struct, TokenInput, for tokenised transactions
* tokenised transactions amount wont be added to main chain amounts as they are essentially a different "coin"
* TokenInput mimics most of KeyInput (standard txs) with some Multisig logic ports (deposit txs)
 * separate token balance from core chain balances, unlocked and locked
* deposits are implemented, yet?
* delete token tx if fails (pop tx)
* add sender context
* this is just a base, lots more needs to be added. a fair chunk was done in tokenised branch